### PR TITLE
relax strict dependency requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ build-backend = "setuptools.build_meta"
 name = "sam2"
 version = "1.0.0"
 dependencies = [
-    "biopython==1.85",
-    "diffusers==0.32.2",
+    "biopython>=1.85",
+    "diffusers>=0.32.2",
     "dm-tree",
-    "mdtraj==1.10.3",
+    "mdtraj>=1.10.3",
     "torch>=1.13.1"
 ]


### PR DESCRIPTION
Most of the requirements were pinned to exact versions which makes dependency solving in a larger project very difficult. I've relaxed them to require at least the version listed.
